### PR TITLE
메인 로그인 화면 애니메이션 설정

### DIFF
--- a/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
+++ b/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
@@ -247,13 +247,25 @@ private extension MainLoginViewController {
     }
     
     private func resignKeyBoard() {
-        // TODO: - Resign 될 때의 애니메이션
-        print("resign")
+        stackView.snp.remakeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(130)
+            $0.leading.trailing.equalTo(view).inset(24)
+        }
+        
+        UIView.animate(withDuration: 0.2) { [weak self] in
+            self?.view.layoutIfNeeded()
+        }
     }
     
     private func becomeKeyBoard() {
-        // TODO: - Become 될 때의 애니메이션
-        print("become")
+        stackView.snp.remakeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalTo(view).inset(24)
+        }
+        
+        UIView.animate(withDuration: 0.2) { [weak self] in
+            self?.view.layoutIfNeeded()
+        }
     }
 }
 

--- a/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
+++ b/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
@@ -156,6 +156,16 @@ final class MainLoginViewController: UIViewController {
                 self?.failure(errorString)
             }
         }.store(in: &cancellables)
+        
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+            .sink { [weak self] _ in
+                self?.resignKeyBoard()
+            }.store(in: &cancellables)
+        
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+            .sink { [weak self] _ in
+                self?.becomeKeyBoard()
+            }.store(in: &cancellables)
     }
     
     private func configureAddSubViews() {
@@ -234,6 +244,16 @@ private extension MainLoginViewController {
     // MARK: - 발생할 수 있는 에러 핸들링
     private func failure(_ errorString : String) {
         print(errorString)
+    }
+    
+    private func resignKeyBoard() {
+        // TODO: - Resign 될 때의 애니메이션
+        print("resign")
+    }
+    
+    private func becomeKeyBoard() {
+        // TODO: - Become 될 때의 애니메이션
+        print("become")
     }
 }
 

--- a/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
+++ b/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
@@ -199,6 +199,7 @@ final class MainLoginViewController: UIViewController {
         
         inputTextField.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(10)
+            $0.height.equalToSuperview().inset(5)
             $0.centerY.equalToSuperview()
         }
         

--- a/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
+++ b/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
@@ -123,6 +123,11 @@ final class MainLoginViewController: UIViewController {
         fatalError("MainLoginViewController - fatalError")
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        inputTextField.resignFirstResponder()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
## 🔥연관된 이슈
- #12 

## 🔥작업
https://github.com/user-attachments/assets/83853c5a-3021-43da-8c61-3a5d4145c16a

### 키보드 Notification으로 감지 (Combine)
```swift
NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
            .sink { [weak self] _ in
                self?.resignKeyBoard()
            }.store(in: &cancellables)
        
NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
    .sink { [weak self] _ in
        self?.becomeKeyBoard()
    }.store(in: &cancellables)
```
기존 NotificationCenter의 메모리 관리 문제를 Combine을 통해서 자동 해제를 하도록 구현했습니다.