### PR TITLE
Alert 생성 및 에러 처리 개선 

### DIFF
--- a/Shuttle_iOS/App/AppDelegate.swift
+++ b/Shuttle_iOS/App/AppDelegate.swift
@@ -1,17 +1,7 @@
-//
-//  AppDelegate.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/25/25.
-//
-
 import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true

--- a/Shuttle_iOS/App/SceneDelegate.swift
+++ b/Shuttle_iOS/App/SceneDelegate.swift
@@ -26,8 +26,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             try await registerViewModel()
             try await registerViewController()
         }
-        catch let error {
-            print((error as? DIError)?.description)
+        catch let error as DIError {
+            print(error.description)
+        } catch {
+            print(error.localizedDescription)
         }
     }
     

--- a/Shuttle_iOS/App/SceneDelegate.swift
+++ b/Shuttle_iOS/App/SceneDelegate.swift
@@ -1,10 +1,3 @@
-//
-//  SceneDelegate.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/25/25.
-//
-
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {

--- a/Shuttle_iOS/Data/UserLoginRepository+Impl.swift
+++ b/Shuttle_iOS/Data/UserLoginRepository+Impl.swift
@@ -1,10 +1,3 @@
-//
-//  UserLoginRepository+Impl.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/31/25.
-//
-
 import Foundation
 
 final class UserLoginRepositoryImpl: UserLoginRepository {

--- a/Shuttle_iOS/Data/UserLoginRepository+Test.swift
+++ b/Shuttle_iOS/Data/UserLoginRepository+Test.swift
@@ -1,10 +1,3 @@
-//
-//  UserLoginRepository+Test.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/31/25.
-//
-
 import Foundation
 
 final class UserLoginRepositoryTest : UserLoginRepository {

--- a/Shuttle_iOS/Domain/UserLoginRepository.swift
+++ b/Shuttle_iOS/Domain/UserLoginRepository.swift
@@ -1,10 +1,3 @@
-//
-//  UserLoginRepository.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/31/25.
-//
-
 import Foundation
 
 protocol UserLoginRepository: Sendable {

--- a/Shuttle_iOS/Domain/UserLoginUseCase.swift
+++ b/Shuttle_iOS/Domain/UserLoginUseCase.swift
@@ -1,10 +1,3 @@
-//
-//  UserLoginUseCase.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/31/25.
-//
-
 import Foundation
 
 final class UserLoginUseCase: Sendable {

--- a/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
+++ b/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
@@ -232,13 +232,13 @@ private extension MainLoginViewController {
     private func userLoginSuccess() {
         print("UserLogin Success")
     }
-    // MARK: - User Login Request (이메일에 요청을 보냄)
+    
     private func userLoginRequest() {
-        print("UserLogin Request")
+        present(UIAlertController.make(message: "메일 요청을 보냈습니다."), animated: true)
     }
-    // MARK: - 발생할 수 있는 에러 핸들링
+
     private func failure(_ errorString : String) {
-        print(errorString)
+        present(UIAlertController.make(message: errorString), animated: true)
     }
     
     private func resignKeyBoard() {

--- a/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
+++ b/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
@@ -1,10 +1,3 @@
-//
-//  MainLoginViewController.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/31/25.
-//
-
 import UIKit
 import SnapKit
 import Combine

--- a/Shuttle_iOS/Presentation/ViewModel/MainLoginViewModel.swift
+++ b/Shuttle_iOS/Presentation/ViewModel/MainLoginViewModel.swift
@@ -1,10 +1,3 @@
-//
-//  MainLoginViewModel.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/31/25.
-//
-
 import UIKit
 import Combine
 

--- a/Shuttle_iOS/Presentation/ViewModel/MainLoginViewModel.swift
+++ b/Shuttle_iOS/Presentation/ViewModel/MainLoginViewModel.swift
@@ -36,7 +36,7 @@ public final class MainLoginViewModel {
     
     private func userLoginTapped(_ email: String) {
         guard let uuidString = UIDevice.current.identifierForVendor?.uuidString else {
-            // 기기 정보를 가져올 수 없습니다.
+            output.send(.failure(DataError.deviceRequestFailure.description))
             return
         }
         do {

--- a/Shuttle_iOS/Presentation/ViewModel/MainLoginViewModel.swift
+++ b/Shuttle_iOS/Presentation/ViewModel/MainLoginViewModel.swift
@@ -43,12 +43,10 @@ public final class MainLoginViewModel {
             try userLoginUseCase.execute(email: email, uuid: uuidString)
             ? output.send(.userLoginSuccess) : output.send(.userLoginRequest)
         }
-        catch let error {
-            guard let errorString = (error as? DataError)?.description else {
-                output.send(.failure("알 수 없는 에러"))
-                return
-            }
-            output.send(.failure(errorString))
+        catch let error as DataError {
+            output.send(.failure(error.description))
+        } catch {
+            output.send(.failure("알 수 없는 에러"))
         }
     }
     

--- a/Shuttle_iOS/Presentation/ViewModel/UserViewModel.swift
+++ b/Shuttle_iOS/Presentation/ViewModel/UserViewModel.swift
@@ -4,7 +4,6 @@
 //
 //  Created by 강대훈 on 4/3/25.
 //
-
 import Foundation
 import Combine
 

--- a/Shuttle_iOS/Utils/Constants.swift
+++ b/Shuttle_iOS/Utils/Constants.swift
@@ -1,10 +1,3 @@
-//
-//  Constants.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/31/25.
-//
-
 import Foundation
 
 public enum Constant {

--- a/Shuttle_iOS/Utils/DIContainer.swift
+++ b/Shuttle_iOS/Utils/DIContainer.swift
@@ -1,10 +1,3 @@
-//
-//  DIContainer.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 4/1/25.
-//
-
 public actor DIContainer {
     
     static let shared = DIContainer()

--- a/Shuttle_iOS/Utils/DIError.swift
+++ b/Shuttle_iOS/Utils/DIError.swift
@@ -1,10 +1,3 @@
-//
-//  DIError.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 4/1/25.
-//
-
 public enum DIError : Error {
     case DIContainerFailure(type: String)
     

--- a/Shuttle_iOS/Utils/DataError.swift
+++ b/Shuttle_iOS/Utils/DataError.swift
@@ -1,10 +1,3 @@
-//
-//  DataError.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 4/1/25.
-//
-
 import Foundation
 
 enum DataError: Error {

--- a/Shuttle_iOS/Utils/DataError.swift
+++ b/Shuttle_iOS/Utils/DataError.swift
@@ -2,11 +2,14 @@ import Foundation
 
 enum DataError: Error {
     case serverConnectFailure
+    case deviceRequestFailure
     
     public var description: String {
         switch self {
         case .serverConnectFailure:
             return "서버 요청 실패! 다시 시도해주세요."
+        case .deviceRequestFailure:
+            return "디바이스 기기 정보를 가져오지 못했습니다."
         }
     }
 }

--- a/Shuttle_iOS/Utils/UIAlertController+Extension.swift
+++ b/Shuttle_iOS/Utils/UIAlertController+Extension.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+/// isError : true -  "확인" 버튼만 나옵니다. (default)
+/// isError : false - "확인", "취소" 버튼이 나옵니다.
+extension UIAlertController {
+    static func make(title: String = "",
+                     message: String,
+                     isError: Bool = true,
+                     defaultLabel: String = "확인",
+                     cancelLabel: String = "취소"
+    ) -> UIAlertController {
+        let alertController = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert
+            )
+        
+        alertController.addAction(.init(title: defaultLabel, style: .default))
+        if !isError {
+            alertController.addAction(.init(title: cancelLabel, style: .cancel))
+        }
+        return alertController
+    }
+}

--- a/Shuttle_iOS/Utils/UIFont+Extension.swift
+++ b/Shuttle_iOS/Utils/UIFont+Extension.swift
@@ -1,10 +1,3 @@
-//
-//  UIFont+Extension.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 3/30/25.
-//
-
 import UIKit
 
 // TODO: - 추후에 에러처리로 바꿔야할지 고민중.


### PR DESCRIPTION
## 🔥연관된 이슈
- #16 

## 🔥작업
<img width="264" alt="스크린샷 2025-04-03 오후 7 04 49" src="https://github.com/user-attachments/assets/27ac471c-d750-4360-bfe4-e784bf445d34" />

### do-catch문 수정
`catch` 타입 캐스팅을 통해서 가독성을 높였습니다.
```swift
do {
    await registerRepository()
    try await registerUseCase()
    try await registerViewModel()
    try await registerViewController()
}
catch let error as DIError {
    print(error.description)
} catch {
    print(error.localizedDescription)
}
```

### AlertController 타입 메서드 추가

> 추후에 상황에 맞게 수정될 가능성이 매우 높습니다.

```swift
/// isError : true -  "확인" 버튼만 나옵니다. (default)
/// isError : false - "확인", "취소" 버튼이 나옵니다.
extension UIAlertController {
    static func make(title: String = "",
                     message: String,
                     isError: Bool = true,
                     defaultLabel: String = "확인",
                     cancelLabel: String = "취소"
    ) -> UIAlertController {
        let alertController = UIAlertController(
            title: title,
            message: message,
            preferredStyle: .alert
            )
        
        alertController.addAction(.init(title: defaultLabel, style: .default))
        if !isError {
            alertController.addAction(.init(title: cancelLabel, style: .cancel))
        }
        return alertController
    }
}
```
