### PR TITLE
유저 로그아웃 구현 및 Alert 리팩토링

### DIFF
--- a/Shuttle_iOS/App/SceneDelegate.swift
+++ b/Shuttle_iOS/App/SceneDelegate.swift
@@ -35,19 +35,27 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     private func registerRepository() async {
         await DIContainer.shared.register(UserLoginRepository.self, UserLoginRepositoryTest())
+        await DIContainer.shared.register(UserLogoutRepository.self, UserLogoutRepositoryTest())
     }
     
     private func registerUseCase() async throws {
         let userLoginRepository = try await DIContainer.shared.resolve(UserLoginRepository.self)
         await DIContainer.shared.register(UserLoginUseCase.self,
                                           UserLoginUseCase(userLoginRepository: userLoginRepository))
+        
+        let userLogoutRepository = try await DIContainer.shared.resolve(UserLogoutRepository.self)
+        await DIContainer.shared.register(UserLogoutUseCase.self,
+                                          UserLogoutUseCase(userLogoutRepository: userLogoutRepository))
     }
     
     private func registerViewModel() async throws {
         let userLoginUseCase = try await DIContainer.shared.resolve(UserLoginUseCase.self)
         await DIContainer.shared.register(MainLoginViewModel.self,
                                           MainLoginViewModel(userLoginUseCase: userLoginUseCase))
-        await DIContainer.shared.register(UserViewModel.self, UserViewModel())
+        
+        let userLogoutUseCase = try await DIContainer.shared.resolve(UserLogoutUseCase.self)
+        await DIContainer.shared.register(UserViewModel.self,
+                                          UserViewModel(userLogoutUseCase: userLogoutUseCase))
     }
     
     private func registerViewController() async throws {

--- a/Shuttle_iOS/App/SceneDelegate.swift
+++ b/Shuttle_iOS/App/SceneDelegate.swift
@@ -10,7 +10,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         Task {
             window = UIWindow(windowScene: windowScene)
             await registerContainer()
-            window?.rootViewController = await createMainViewController()
+            guard let rootVC = await createMainViewController() else {
+                return
+            }
+            window?.rootViewController = UINavigationController(rootViewController: rootVC)
             window?.makeKeyAndVisible()
         }
     }

--- a/Shuttle_iOS/Data/UserLoginRepository+Test.swift
+++ b/Shuttle_iOS/Data/UserLoginRepository+Test.swift
@@ -2,12 +2,12 @@ import Foundation
 
 final class UserLoginRepositoryTest : UserLoginRepository {
     func existLocalData(email: String, uuid: String) -> Bool {
-        (UserDefaults.standard.string(forKey: email) ?? "") == uuid
+        (UserDefaults.standard.string(forKey: uuid) ?? "") == email
     }
     
     func existServerData(email: String, uuid: String) throws -> Bool {
         // TODO: - 서버에 있는지 확인하고 있으면 UserDefaults에 저장해줘야 함.
-        UserDefaults.standard.set(uuid, forKey: email)
+        UserDefaults.standard.set(email, forKey: uuid)
         throw DataError.serverConnectFailure
     }
     

--- a/Shuttle_iOS/Data/UserLogoutRepository+Impl.swift
+++ b/Shuttle_iOS/Data/UserLogoutRepository+Impl.swift
@@ -1,0 +1,7 @@
+//
+//  UserLogoutRepository+Impl.swift
+//  Shuttle_iOS
+//
+//  Created by 강대훈 on 4/7/25.
+//
+

--- a/Shuttle_iOS/Data/UserLogoutRepository+Impl.swift
+++ b/Shuttle_iOS/Data/UserLogoutRepository+Impl.swift
@@ -5,3 +5,6 @@
 //  Created by 강대훈 on 4/7/25.
 //
 
+final class UserLogoutRepositoryImpl {
+    
+}

--- a/Shuttle_iOS/Data/UserLogoutRepository+Impl.swift
+++ b/Shuttle_iOS/Data/UserLogoutRepository+Impl.swift
@@ -1,9 +1,4 @@
-//
-//  UserLogoutRepository+Impl.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 4/7/25.
-//
+import UIKit
 
 final class UserLogoutRepositoryImpl: UserLogoutRepository {
     func executeLogout(uuidString: String) {

--- a/Shuttle_iOS/Data/UserLogoutRepository+Impl.swift
+++ b/Shuttle_iOS/Data/UserLogoutRepository+Impl.swift
@@ -5,6 +5,8 @@
 //  Created by 강대훈 on 4/7/25.
 //
 
-final class UserLogoutRepositoryImpl {
-    
+final class UserLogoutRepositoryImpl: UserLogoutRepository {
+    func executeLogout(uuidString: String) {
+        UserDefaults.standard.removeObject(forKey: uuidString)
+    }
 }

--- a/Shuttle_iOS/Data/UserLogoutRepository+Test.swift
+++ b/Shuttle_iOS/Data/UserLogoutRepository+Test.swift
@@ -1,10 +1,7 @@
-//
-//  UserLogoutRepository+Test.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 4/7/25.
-//
+import UIKit
 
-final class UserLogoutRepositoryTest {
-    
+final class UserLogoutRepositoryTest: UserLogoutRepository {
+    func executeLogout(uuidString: String) {
+        UserDefaults.standard.removeObject(forKey: uuidString)
+    }
 }

--- a/Shuttle_iOS/Data/UserLogoutRepository+Test.swift
+++ b/Shuttle_iOS/Data/UserLogoutRepository+Test.swift
@@ -5,3 +5,6 @@
 //  Created by 강대훈 on 4/7/25.
 //
 
+final class UserLogoutRepositoryTest {
+    
+}

--- a/Shuttle_iOS/Data/UserLogoutRepository+Test.swift
+++ b/Shuttle_iOS/Data/UserLogoutRepository+Test.swift
@@ -1,0 +1,7 @@
+//
+//  UserLogoutRepository+Test.swift
+//  Shuttle_iOS
+//
+//  Created by 강대훈 on 4/7/25.
+//
+

--- a/Shuttle_iOS/Domain/UserLogoutRepository.swift
+++ b/Shuttle_iOS/Domain/UserLogoutRepository.swift
@@ -5,3 +5,6 @@
 //  Created by 강대훈 on 4/7/25.
 //
 
+final class UserLogoutRepository: UserLogoutRepositoryTest {
+    
+}

--- a/Shuttle_iOS/Domain/UserLogoutRepository.swift
+++ b/Shuttle_iOS/Domain/UserLogoutRepository.swift
@@ -5,6 +5,6 @@
 //  Created by 강대훈 on 4/7/25.
 //
 
-final class UserLogoutRepository: UserLogoutRepositoryTest {
+protocol UserLogoutRepository: UserLogoutRepositoryTest {
     
 }

--- a/Shuttle_iOS/Domain/UserLogoutRepository.swift
+++ b/Shuttle_iOS/Domain/UserLogoutRepository.swift
@@ -1,0 +1,7 @@
+//
+//  UserLogoutRepository.swift
+//  Shuttle_iOS
+//
+//  Created by 강대훈 on 4/7/25.
+//
+

--- a/Shuttle_iOS/Domain/UserLogoutRepository.swift
+++ b/Shuttle_iOS/Domain/UserLogoutRepository.swift
@@ -5,6 +5,6 @@
 //  Created by 강대훈 on 4/7/25.
 //
 
-protocol UserLogoutRepository: UserLogoutRepositoryTest {
-    
+protocol UserLogoutRepository: Sendable {
+    func executeLogout(uuidString: String)
 }

--- a/Shuttle_iOS/Domain/UserLogoutUseCase.swift
+++ b/Shuttle_iOS/Domain/UserLogoutUseCase.swift
@@ -1,0 +1,7 @@
+//
+//  UserLogoutUseCase.swift
+//  Shuttle_iOS
+//
+//  Created by 강대훈 on 4/7/25.
+//
+

--- a/Shuttle_iOS/Domain/UserLogoutUseCase.swift
+++ b/Shuttle_iOS/Domain/UserLogoutUseCase.swift
@@ -5,3 +5,6 @@
 //  Created by 강대훈 on 4/7/25.
 //
 
+final class UserLogoutUseCase {
+    
+}

--- a/Shuttle_iOS/Domain/UserLogoutUseCase.swift
+++ b/Shuttle_iOS/Domain/UserLogoutUseCase.swift
@@ -5,6 +5,14 @@
 //  Created by 강대훈 on 4/7/25.
 //
 
-final class UserLogoutUseCase {
+final class UserLogoutUseCase: Sendable {
+    private let userLogoutRepository: UserLogoutRepository
     
+    init(userLogoutRepository: UserLogoutRepository) {
+        self.userLogoutRepository = userLogoutRepository
+    }
+    
+    func execute(uuidString: String) {
+        userLogoutRepository.executeLogout(uuidString: uuidString)
+    }
 }

--- a/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
+++ b/Shuttle_iOS/Presentation/View/MainLoginViewController.swift
@@ -23,7 +23,7 @@ final class MainLoginViewController: UIViewController {
     private let titleLabel: UILabel = {
         let l = UILabel()
         l.font = UIFont.pretendardExtraBold(size: 30.0)
-        l.text = "셔틀셔틀"
+        l.text = ""
         l.textAlignment = .center
         l.addCharecterString()
         return l
@@ -230,15 +230,23 @@ final class MainLoginViewController: UIViewController {
 private extension MainLoginViewController {
     // MARK: - User Login Success (User 화면으로 이동)
     private func userLoginSuccess() {
-        print("UserLogin Success")
+        Task {
+            do {
+                let userViewController = try await DIContainer.shared.resolve(UserViewController.self)
+                navigationController?.pushViewController(userViewController, animated: true)
+            }
+            catch {
+                print(error.localizedDescription)
+            }
+        }
     }
     
     private func userLoginRequest() {
-        present(UIAlertController.make(message: "메일 요청을 보냈습니다."), animated: true)
+        present(UIAlertController.alert(message: "메일 요청을 보냈습니다."), animated: true)
     }
 
     private func failure(_ errorString : String) {
-        present(UIAlertController.make(message: errorString), animated: true)
+        present(UIAlertController.errorAlert(message: errorString), animated: true)
     }
     
     private func resignKeyBoard() {

--- a/Shuttle_iOS/Presentation/View/UserViewController.swift
+++ b/Shuttle_iOS/Presentation/View/UserViewController.swift
@@ -5,7 +5,6 @@ import CoreLocation
 import Combine
 
 final class UserViewController: UIViewController {
-    
     private var viewModel : UserViewModel
     private let input = PassthroughSubject<UserViewModel.Input, Never>()
     private var cancellables : Set<AnyCancellable> = .init()
@@ -81,6 +80,8 @@ final class UserViewController: UIViewController {
     
     private func setup() {
         view.backgroundColor = .white
+        
+        navigationController?.setNavigationBarHidden(true, animated: false)
         
         mapView.delegate = self
         mapView.preferredConfiguration = MKStandardMapConfiguration() // 기본 지도
@@ -188,8 +189,11 @@ final class UserViewController: UIViewController {
 
 private extension UserViewController {
     private func userLogout() {
-        // TODO: - 화면 전환
-        print("userLogout")
+        present(UIAlertController.alert(
+            title: "로그이웃",
+            message: "정말로 로그아웃하시겠습니까?") { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+        }, animated: true)
     }
     
     private func presentFAQ() {

--- a/Shuttle_iOS/Presentation/ViewModel/UserViewModel.swift
+++ b/Shuttle_iOS/Presentation/ViewModel/UserViewModel.swift
@@ -1,11 +1,6 @@
-//
-//  UserViewModel.swift
-//  Shuttle_iOS
-//
-//  Created by 강대훈 on 4/3/25.
-//
 import Foundation
 import Combine
+import UIKit
 
 @MainActor
 final class UserViewModel {
@@ -25,6 +20,11 @@ final class UserViewModel {
     
     private let output = PassthroughSubject<Output, Never>()
     private var cancellables: Set<AnyCancellable> = .init()
+    private var userLogoutUseCase: UserLogoutUseCase
+    
+    init(userLogoutUseCase: UserLogoutUseCase) {
+        self.userLogoutUseCase = userLogoutUseCase
+    }
     
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
         input.sink { [weak self] event in
@@ -44,7 +44,10 @@ final class UserViewModel {
     }
     
     private func logoutTapped() {
-        // TODO: - 로그아웃 UseCase
+        guard let uuidString = UIDevice.current.identifierForVendor?.uuidString else {
+            return
+        }
+        userLogoutUseCase.execute(uuidString: uuidString)
         output.send(.userLogout)
     }
     

--- a/Shuttle_iOS/Utils/UIAlertController+Extension.swift
+++ b/Shuttle_iOS/Utils/UIAlertController+Extension.swift
@@ -1,24 +1,47 @@
 import UIKit
 
-/// isError : true -  "확인" 버튼만 나옵니다. (default)
-/// isError : false - "확인", "취소" 버튼이 나옵니다.
 extension UIAlertController {
-    static func make(title: String = "",
-                     message: String,
-                     isError: Bool = true,
-                     defaultLabel: String = "확인",
-                     cancelLabel: String = "취소"
+    /// 오류 발생시 사용하는 Alert
+    static func errorAlert(message: String) -> UIAlertController {
+        let alertController = UIAlertController(
+            title: "",
+            message: message,
+            preferredStyle: .alert
+            )
+        
+        alertController.addAction(
+            .init(title: "확인",
+                  style: .default)
+        )
+        
+        return alertController
+    }
+    
+    static func alert(
+        title: String = "",
+        message: String = "",
+        defaultCompletion: (() -> Void)? = nil,
+        cancelCompletion: (() -> Void)? = nil
     ) -> UIAlertController {
         let alertController = UIAlertController(
             title: title,
             message: message,
             preferredStyle: .alert
-            )
+        )
         
-        alertController.addAction(.init(title: defaultLabel, style: .default))
-        if !isError {
-            alertController.addAction(.init(title: cancelLabel, style: .cancel))
+        let defaultAction = UIAlertAction(
+            title: "확인",
+            style: .default) { _ in
+            defaultCompletion?()
         }
+        
+        let cancelAction = UIAlertAction(
+            title: "취소",
+            style: .cancel) { _ in
+            cancelCompletion?()
+        }
+        alertController.addAction(defaultAction)
+        alertController.addAction(cancelAction)
         return alertController
     }
 }


### PR DESCRIPTION
## 🔥연관된 이슈
- #19 

## 🔥작업
https://github.com/user-attachments/assets/e3cd2b1f-2927-4a07-89d2-6ab99c5d8ba3

### 로그아웃 구현
로그아웃 할 때 `UserDefaults` 에서 매핑하는 이메일을 삭제합니다.
<img width="585" alt="image" src="https://github.com/user-attachments/assets/524d792b-6645-4a1b-905f-c16e1d2618e2" />

### Alert 리팩토링
에러 발생시에 알려주는 Alert와 평시에 사용하는 Alert를 분리했습니다.

- 에러 발생시
```swift
static func errorAlert(message: String) -> UIAlertController {
    let alertController = UIAlertController(
        title: "",
        message: message,
        preferredStyle: .alert
        )
    
    alertController.addAction(
        .init(title: "확인",
              style: .default)
    )
    
    return alertController
}
```

- 평시 사용시
```swift
static func alert(
    title: String = "",
    message: String = "",
    defaultCompletion: (() -> Void)? = nil,
    cancelCompletion: (() -> Void)? = nil
) -> UIAlertController {
    let alertController = UIAlertController(
        title: title,
        message: message,
        preferredStyle: .alert
    )
    
    let defaultAction = UIAlertAction(
        title: "확인",
        style: .default) { _ in
        defaultCompletion?()
    }
    
    let cancelAction = UIAlertAction(
        title: "취소",
        style: .cancel) { _ in
        cancelCompletion?()
    }
    alertController.addAction(defaultAction)
    alertController.addAction(cancelAction)
    return alertController
}
```
