### PR TITLE
커스텀 패딩 라벨 생성 및 적용

### DIFF
--- a/Shuttle_iOS/Presentation/View/Cell/BusCollectionViewCell.swift
+++ b/Shuttle_iOS/Presentation/View/Cell/BusCollectionViewCell.swift
@@ -33,6 +33,7 @@ final class BusCollectionViewCell: UICollectionViewCell {
     }
     
     override func layoutSubviews() {
+        super.layoutSubviews()
         contentView.layer.cornerRadius = contentView.frame.height / 2
     }
     

--- a/Shuttle_iOS/Presentation/View/Cell/StationTableViewCell.swift
+++ b/Shuttle_iOS/Presentation/View/Cell/StationTableViewCell.swift
@@ -15,7 +15,7 @@ final class StationTableViewCell: UITableViewCell {
     }()
     
     private let additionLabel: UILabel = {
-        let l = UILabel()
+        let l = CustomPaddingLabel()
         l.clipsToBounds = true
         l.font = .pretendardSemiBold(size: 12.0)
         l.textColor = .hsBlack
@@ -40,6 +40,7 @@ final class StationTableViewCell: UITableViewCell {
     }
     
     override func layoutSubviews() {
+        super.layoutSubviews()
         additionLabel.layer.cornerRadius = additionLabel.frame.height / 2
     }
     
@@ -62,12 +63,6 @@ final class StationTableViewCell: UITableViewCell {
         // TODO: - Lat, Lon 어떻게 해야할지 고민
         stationLabel.text = stationEntity.name
         additionLabel.text = stationEntity.additionalName
-        
-        additionLabel.snp.remakeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.width.equalTo(additionLabel.intrinsicContentSize.width + 15)
-            $0.leading.equalTo(stationLabel.snp.trailing).offset(10)
-        }
         contentView.layoutIfNeeded()
     }
 }

--- a/Shuttle_iOS/Presentation/View/User/CustomView/CustomPaddingLabel.swift
+++ b/Shuttle_iOS/Presentation/View/User/CustomView/CustomPaddingLabel.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+final class CustomPaddingLabel: UILabel {
+    private var topInset: CGFloat = 2
+    private var bottomInset: CGFloat = 2
+    private var leftInset: CGFloat = 7
+    private var rightInset: CGFloat = 7
+    
+    override func drawText(in rect: CGRect) {
+        let inset: UIEdgeInsets = UIEdgeInsets(
+            top: topInset,
+            left: leftInset,
+            bottom: bottomInset,
+            right: rightInset
+        )
+        super.drawText(in: rect.inset(by: inset))
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        if (size.width == 0) { return size }
+        return CGSize(
+            width: size.width + leftInset + rightInset,
+            height: size.height + topInset + bottomInset
+        )
+    }
+}
+


### PR DESCRIPTION
## 🔥작업

### 커스텀 패딩 라벨 생성
라벨에 배경이 들어가기 때문에 패딩을 주어서 생성합니다. 

`UILabel`은 IntrinsicSize를 사용함으로 override를 사용해서 다시 패딩이 적용된 사이즈를 갖도록 구현했습니다.

하지만 아무런 값이 없는 라벨도 배경이 나타나는 문제로 인해서 IntrinsicContentSize가 0이면 패딩을 적용하지 않는 방안을 추가했습니다.
```swift
if (size.width == 0) { return size }
```

```swift
final class CustomPaddingLabel: UILabel {
    private var topInset: CGFloat = 2
    private var bottomInset: CGFloat = 2
    private var leftInset: CGFloat = 7
    private var rightInset: CGFloat = 7
    
    override func drawText(in rect: CGRect) {
        let inset: UIEdgeInsets = UIEdgeInsets(
            top: topInset,
            left: leftInset,
            bottom: bottomInset,
            right: rightInset
        )
        super.drawText(in: rect.inset(by: inset))
    }
    
    override var intrinsicContentSize: CGSize {
        let size = super.intrinsicContentSize
        if (size.width == 0) { return size }
        return CGSize(
            width: size.width + leftInset + rightInset,
            height: size.height + topInset + bottomInset
        )
    }
}
```

### 적용
`UILabel`로 업캐스팅해서 사용해도 다형성으로 인해서 패딩이 잘 적용되기 때문에 캡슐화했습니다.

```swift
    private let additionLabel: UILabel = {
        let l = CustomPaddingLabel()
        l.clipsToBounds = true
        l.font = .pretendardSemiBold(size: 12.0)
        l.textColor = .hsBlack
        l.backgroundColor = .blue.withAlphaComponent(0.3)
        l.textAlignment = .center
        return l
    }()
```
